### PR TITLE
Non-Web Embeddings Section and wac project

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [Online Playground](#online-playground)
 - [Tutorials](#tutorials)
 - [Compilers](#compilers)
+- [Non-Web Embeddings](#non-web-embeddings)
 - [Projects](#projects)
   - [DOM](#dom)
   - [WebGL](#webgl)
@@ -53,6 +54,9 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [Binaryen - Binaryen is a compiler and toolchain infrastructure library for WebAssembly, written in C++](https://github.com/WebAssembly/binaryen)
 - [Rust - A safe, concurrent, practical language](https://blog.rust-lang.org/2016/12/22/Rust-1.14.html)
 - [ilwasm - CIL to WebAssembly compiler](https://github.com/kg/ilwasm)
+
+### Non-Web Embeddings
+- [wac - WebAssembly in C (x86)](https://github.com/kanaka/wac)
 
 ### Projects
 


### PR DESCRIPTION
The general concept of non-web embeddings is described at
http://webassembly.org/docs/non-web/

The also adds a link to wac: https://github.com/kanaka/wac (caveat:
I am the creator of wac).

- [X] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).