### PR TITLE
Add YAKC 8-bit emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [wasm-init - Work environment and code generator for WebAssembly projects](https://github.com/shamadee/wasm-init)
 - [wasm - Python WebAssembly decoder & disassembler library](https://github.com/athre0z/wasm)
 - [MXnet.js - ASM.js build of MXNet, deep learning (neural nets and so) library](https://github.com/dmlc/mxnet.js/)
+- [YAKC - a multi-system 8-bit emulator written in C++](https://floooh.github.io/virtualkc/index_wasm.html)
 
 ### Tools
 


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).

This PR adds a link to the WASM version of my multi-system 8-bit emulator, the github repo is here: https://github.com/floooh/yakc