### PR TITLE
Add GNU Toolchain to compilers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [Binaryen - Binaryen is a compiler and toolchain infrastructure library for WebAssembly, written in C++](https://github.com/WebAssembly/binaryen)
 - [Rust - A safe, concurrent, practical language](https://blog.rust-lang.org/2016/12/22/Rust-1.14.html)
 - [ilwasm - CIL to WebAssembly compiler](https://github.com/kg/ilwasm)
+- [WebAssembly for the GNU Toolchain](https://sourceware.org/ml/binutils/2017-03/msg00044.html)
 
 ### Non-Web Embeddings
 - [wac - WebAssembly in C (x86)](https://github.com/kanaka/wac)


### PR DESCRIPTION
This changeset adds to the list of compilers the announcement of WebAssembly support in the GNU toolchain (binutils, etc.)

- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).