### PR TITLE
add link to Assembleash Playgound

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [WebAssembly Explorer](https://mbebenita.github.io/WasmExplorer/)
 - [WebAssembly Playground](http://ast.run/)
 - [WasmFiddle](https://wasdk.github.io/WasmFiddle/)
+- [Assembleash - WebAssembly and Typescript-like languages playground](https://github.com/MaxGraey/Assembleash)
 
 ### Tutorials
 - [Developer's Guide](http://webassembly.org/getting-started/developers-guide/)


### PR DESCRIPTION
Assembleash is playground for WebAssembly and Typescript-like (AssemblyScript, TurboScript and Speedy.js) languages.