### PR TITLE
Add a link to Walt, Alternative Syntax for wasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [Rusty Web](https://davidmcneil.github.io/the-rusty-web/)
 - [parity-wasm - WebAssembly interpreter, decoder and encoder in pure Rust](https://github.com/paritytech/parity-wasm)
 - [wah - a slightly higher-level language superset of webassembly](https://github.com/tmcw/wah)
+- [Walt - Alternative Syntax for WebAssembly](https://github.com/ballercat/walt)
 
 #### node.js
 - [webassembly - A minimal toolkit and runtime to produce and run WebAssembly modules.](https://github.com/dcodeIO/webassembly)


### PR DESCRIPTION
Hi, I would like to add a link to [Walt](https://github.com/ballercat/walt) as one of the language options. 

Thanks!

- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).