### PR TITLE
 Add to Examples category CppOpenGLWebAssemblyCMake

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [WebAssembly Wikipedia](https://en.wikipedia.org/wiki/WebAssembly)
 - [WebAssembly Specification](https://webassembly.github.io/spec/)
 - [WebAssembly and Friends Roadmap](https://wasmdash.appspot.com/)
-- [WebAssembly Rocks](https://www.wasmrocks.com/)
+- [WebAssembly Rocks](http://www.wasmrocks.com/)
 
 ### Online Playground
 - [WebAssembly Explorer](https://mbebenita.github.io/WasmExplorer/)

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [webassembly-examples - From Simple To Complex.](https://github.com/reklatsmasters/webassembly-examples)
 - [D3 force layout with WebAssembly](https://github.com/ColinEberhardt/d3-wasm-force/blob/master/README.md)
 - [wasmBoy - Gameboy Emulator Library written in Web Assembly using AssemblyScript](https://github.com/torch2424/wasmBoy)
+- [CppOpenGLWebAssemblyCMake - C++/OpenGL/OpenAL/GLFW/GLM based app built with CMake to native or WebAssembly](https://github.com/lukka/CppOpenGLWebAssemblyCMake)
 
 ### Benchmarks
 - [WebAssembly Video Editor](https://d2jta7o2zej4pf.cloudfront.net/)


### PR DESCRIPTION
Add to the Examples category an example of an app based on C++/OpenGL/OpenAL/GLFW/GLM, built with CMake targeting native Linux/Macos/WIndows or WebAssembly (by means of Emscripten SDK).
This example shows how to create an application that works natively or with WebAssembly by using the same audio/video rendering engine source code.

- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).