### PR TITLE
Add PSPDFKit for Web Demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [Symatem - an Ontology Engine, Visualizer, and Editor](http://symatem.github.io/)
 - [Epic Zen Garden](https://s3.amazonaws.com/mozilla-games/ZenGarden/EpicZenGarden.html)
 - [Funky Karts](http://funkykarts.rocks/demo.html)
+- [PSPDFKit for Web](https://web-preview.pspdfkit.com/standalone/6)
 
 ### Resources in other languages
 


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).

For quite some time we have a public preview of our WebAssembly PDF engine online. It ships with all optimizations that are available today and you can even open your own PDFs (without them being sent to our servers.