### PR TITLE
Add PSPDFKit WebAssembly Benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [Cubes JS](http://kripken.github.io/ammo.js/examples/webgl_demo/ammo.html) vs [Cubes (WebAssembly)](http://kripken.github.com/ammo.js/examples/webgl_demo/ammo.wasm.html)
 - [JavaScript vs WebAssembly easy benchmark](https://takahirox.github.io/WebAssembly-benchmark/)
 - [Performance Testing Web Assembly vs JavaScript](https://medium.com/samsung-internet-dev/performance-testing-web-assembly-vs-javascript-e07506fd5875)
+- [A Real-World WebAssembly Benchmark by PSPDFKit](https://pspdfkit.com/blog/2018/a-real-world-webassembly-benchmark/)
 
 ### Articles
 - [Writing WebAssembly By Hand (2018)](http://blog.scottlogic.com/2018/04/26/webassembly-by-hand.html)


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).

We developed a WebAssembly benchmark and gathered input from all browser vendors.  The premise is that we want a full-stack test that reflects the performance of [PSPDFKit for Web](https://pspdfkit.com/pdf-sdk/web/) in a metric that we can compare between browsers and over time.