### PR TITLE
Added WasmBoy to Wasm Demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [PSPDFKit for Web - a WebAssembly-based PDF viewer with annotation features](https://web-preview.pspdfkit.com/standalone/6)
 - [Uno Platform Playground - a WebAssembly-based XAML playground](http://playground.platform.uno)
 - [Roslyn Quoter - a WebAssembly-based Roslyn-based C# code quoter](http://roslynquoter-wasm.platform.uno/)
+- [WasmBoy - Gameboy / Gameboy Color Emulator written for Web Assembly using AssemblyScript. 🕸️Shell/Debugger in Preact. ⚛️](https://github.com/torch2424/wasmBoy)
 
 ### Resources in other languages
 


### PR DESCRIPTION
Hello!

I was hoping I could add my GB / GBC emulator (Made with AssemblyScript) to the repo: https://github.com/torch2424/wasmBoy

Let me know if demos is the correct section.

Thank you! 😄

- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).