### PR TITLE
Add wasm-astar example

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [D3 force layout with WebAssembly](https://github.com/ColinEberhardt/d3-wasm-force/blob/master/README.md)
 - [wasmBoy - Gameboy Emulator Library written in Web Assembly using AssemblyScript](https://github.com/torch2424/wasmBoy)
 - [CppOpenGLWebAssemblyCMake - C++/OpenGL/OpenAL/GLFW/GLM based app built with CMake to native or WebAssembly](https://github.com/lukka/CppOpenGLWebAssemblyCMake)
+- [WebAssembly A* Pathfinding](https://github.com/jakedeichert/wasm-astar)
 
 ### Benchmarks
 - [WebAssembly Video Editor](https://d2jta7o2zej4pf.cloudfront.net/)


### PR DESCRIPTION
Hey! I'm wondering if my example project/article fits in here somewhere?

[WebAssembly A* Pathfinding](https://github.com/jakedeichert/wasm-astar)

If not, feel free to close! 🙂

- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).

