### PR TITLE
Add Wasabi

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [warpy - WebAssembly in RPython](https://github.com/kanaka/warpy)
 - [wasmtime - Standalone WebAssembly Runtime](https://github.com/CraneStation/wasmtime)
 - [pywasm - WebAssembly interpreter written in pure Python](https://github.com/mohanson/pywasm)
+- [Wasabi - WebAssembly runtime designed for multitenancy](https://github.com/maxmcd/wasabi)
 
 
 ### Projects


### PR DESCRIPTION
Adding Wasabi to the Non-Web Embeddings section. Wasabi is a WebAssembly runtime for Go (and other things).

https://github.com/maxmcd/wasabi/

- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).

