### PR TITLE
Added go-web-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [ewasm - Ethereum flavored WebAssembly](https://github.com/ewasm)
 - [webm-wasm - Create webm videos in JavaScript via WebAssembly](https://github.com/GoogleChromeLabs/webm-wasm)
 - [wasm-pdf – Generate PDF files with JavaScript/WASM](https://github.com/jussiniinikoski/wasm-pdf)
+- [go-web-app – Quickly setup Go + WebAssembly frontend apps](https://github.com/talentlessguy/go-web-app)
 
 ## Languages
 


### PR DESCRIPTION
[go-web-app](https://github.com/talentlessguy/go-web-app) – CLI for quickly bootstrapping Go + WASM frontend apps.

- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).