### PR TITLE
Adding Example Link: sweet-webassembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [wasmBoy - Gameboy Emulator Library written in Web Assembly using AssemblyScript](https://github.com/torch2424/wasmBoy)
 - [CppOpenGLWebAssemblyCMake - C++/OpenGL/OpenAL/GLFW/GLM based app built with CMake to native or WebAssembly](https://github.com/lukka/CppOpenGLWebAssemblyCMake)
 - [WebAssembly A* Pathfinding](https://github.com/jakedeichert/wasm-astar)
+- [WebAssembly Quickstart](https://github.com/simplygreatwork/sweet-webassembly)
 
 ## Benchmarks
 - [WebAssembly Video Editor](https://d2jta7o2zej4pf.cloudfront.net/)


### PR DESCRIPTION
This pull request is to add an example link to my project: [sweet-webassembly](https://github.com/simplygreatwork/sweet-webassembly). "Get started with WebAssembly text format syntax and macros."

- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).