### PR TITLE
Add Manticore

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [wasmtime - Standalone WebAssembly Runtime](https://github.com/CraneStation/wasmtime)
 - [pywasm - WebAssembly interpreter written in pure Python](https://github.com/mohanson/pywasm)
 - [Wasabi - WebAssembly runtime designed for multitenancy](https://github.com/maxmcd/wasabi)
+- [Manticore - Symbolic execution engine with support for WebAssembly](https://github.com/trailofbits/manticore)
 
 
 ## Projects


### PR DESCRIPTION
Manticore (https://github.com/trailofbits/manticore) is a symbolic execution engine written in Python that can symbolically evaluate WebAssembly functions. That means that it can call a WebAssembly function with a symbolic value and determine all the possible outputs of that function, including deriving the concrete inputs that produce each output. 

I've written a blog post with more information about WASM support in Manticore here: https://blog.trailofbits.com/2020/01/31/symbolically-executing-webassembly-in-manticore/

- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).