### PR TITLE
Add Vecty, a Go web framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [go-vdom-wasm - Webassembly VDOM to create web application using Golang(experimental)](https://github.com/mfrachet/go-vdom-wasm)
 - [seed - A Rust framework for creating web apps](https://seed-rs.org/)
 - [Vugu - A modern UI library for Go+WebAssembly](https://www.vugu.org/)
+- [Vecty - Lets you build responsive and dynamic web frontends in Go using WebAssembly](https://vecty.io)
 
 ### Data processing
 - [jq-web - the JSON processing tool jq ported to the web with Emscripten](https://github.com/fiatjaf/jq-web)


### PR DESCRIPTION
Vecty lets you build responsive and dynamic web frontends in Go using WebAssembly, competing with modern web frameworks like React & VueJS.

Repository: https://github.com/hexops/vecty

Disclaimer: I am the author of Vecty - I saw this page was linked from https://github.com/golang/go/wiki/WebAssembly#other-webassembly-resources and Vecty is fairly popular (~2k stars) so I figured I would contribute it. Not sure if that's allowed, feel free to close if not.

- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).