### PR TITLE
Added the "WebAssembly threads in Firefox" article.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [Wasmbyexample - Hands-On Introduction Examples and Tutorials for Webassembly](https://wasmbyexample.dev/)
 - [Hands-On Webassembly: Try the Basics (2020)](https://evilmartians.com/chronicles/hands-on-webassembly-try-the-basics) 
 - [First steps with WebAssembly in Rust (2020)](https://aralroca.com/blog/first-steps-webassembly-rust)
+- [WebAssembly threads in Firefox (2020)](https://cggallant.blogspot.com/2020/07/webassembly-threads-in-firefox.html)
 - [Using the import statement with an Emscripten-generated module in Vue.js (2020)](https://cggallant.blogspot.com/2020/01/the-import-statement-with-emscripten.html)
 - [Hit the Ground Running with WebAssembly (2019)](https://medium.com/@robaboukhalil/hit-the-ground-running-with-webassembly-56cf9b2fa35d)
 - [Uno Platform Bootcamp - single-source WASM & Mobile app tutorial (2019)](https://github.com/unoplatform/workshops/tree/master/uno-bootcamp)


### PR DESCRIPTION
Added the "WebAssembly threads in Firefox" article to the Tutorials section. This article shows you how to extend Python's Simple HTTP Server in order to return the necessary response headers to enable the SharedArrayBuffer in Firefox (these headers will become the norm in all browsers in the near future). The article then shows how to use WebAssembly threads to convert a user-supplied image to greyscale.

- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).