### PR TITLE
Add datamodel

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 
 ### Data processing
 - [jq-web - the JSON processing tool jq ported to the web with Emscripten](https://github.com/fiatjaf/jq-web)
+- [DataModel – Relational algebra compliant in memory tabular data store using WebAssembly](https://github.com/chartshq/datamodel)
 
 ### WebGL
 - [ammo.js - direct port of the Bullet physics engine to JavaScript using Emscripten](https://github.com/kripken/ammo.js)


### PR DESCRIPTION
DataModel is a in-memory datastore with webassembly powering [Muze](https://muzejs.org)

- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).