### PR TITLE
demos: add aphros (finite volume solver)

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [The Web Assembles](http://blog.scottlogic.com/ceberhardt/assets/white-papers/the-web-assembles.pdf)
 
 ## Demos
+- [Aphrós - finite volume solver for incompressible multiphase flows](https://cselab.github.io/aphros/wasm/hydro.html)
 - [Cubes - direct port of the Bullet physics engine](http://kripken.github.io/ammo.js/examples/webgl_demo/ammo.wasm.html)
 - [Basic4GL](http://basic4gl.net/mobile/Development/webasm/basic4gl.html)
 - [Symatem - an Ontology Engine, Visualizer, and Editor](http://symatem.github.io/)


### PR DESCRIPTION
We compile our [scientific fluid code Aphros](https://github.com/cselab/aphros) as a WebAssembly library and made [a demo](https://cselab.github.io/aphros/wasm/hydro.html).
- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).