### PR TITLE
Adding Ruffle

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [parity-wasm - WebAssembly serialization/deserialization library in pure Rust](https://github.com/paritytech/parity-wasm)
 - [wasmi - WebAssembly interpreter in pure Rust](https://github.com/paritytech/wasmi)
 - [awesome-rust](https://github.com/rust-unofficial/awesome-rust) (*has scattered references to targeting WASM*)
+- [Ruffle - Adobe Flash Player emulator written in the Rust](https://github.com/ruffle-rs/ruffle)
 
 ### WASM-like
 - [wah - a slightly higher-level language superset of webassembly](https://github.com/tmcw/wah)


### PR DESCRIPTION
Adding Ruffle, an Adobe Flash Player emulator written in the Rust, it targets both the desktop and the web using WebAssembly.

- [+ ] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [ +] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).