### PR TITLE
Add a new js vs wasm benchmark running in browser/nodejs

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [Performance Testing Web Assembly vs JavaScript](https://medium.com/samsung-internet-dev/performance-testing-web-assembly-vs-javascript-e07506fd5875)
 - [A Real-World WebAssembly Benchmark by PSPDFKit](https://pspdfkit.com/blog/2018/a-real-world-webassembly-benchmark/)
 - [Wasm vs. PNaCl Performance Benchmark by PDFTron](https://www.pdftron.com/blog/wasm/wasm-vs-pnacl/)
+- [JavaScript vs WebAssembly running in Browser/Nodejs](https://originjs.org/WASM-benchmark/)
 
 ## Job Boards
 - [WebAssembly Jobs](https://webassemblyjobs.com)


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).

This benchmark can be run in [browser](https://originjs.org/WASM-benchmark/) or [nodejs](https://github.com/originjs/WASM-benchmark)