### PR TITLE
Add link to FutureCoder, which runs on Pyodide

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 
 ### Python
 - [Pyodide - The Python scientific stack running in the browser](https://github.com/iodide-project/pyodide)
+- [futurecoder](https://github.com/alexmojaki/futurecoder) is an interactive Python course running on Pyodide. It includes an
+  [IDE](https://futurecoder.io/course/#ide) with a REPL, debuggers, and supports Pyodide's `micropip`.
 - [Rocket game - Rocket, written in Rust, compiled to WASM, running in Python](https://github.com/almarklein/rocket_rust_py/) (using [PPCI](http://ppci.readthedocs.io))
 
 ### Rust


### PR DESCRIPTION
Added a link to https://github.com/alexmojaki/futurecoder . The description text is adapted from this page: https://github.com/pyodide/pyodide/edit/stable/docs/project/related-projects.md

I put it right below the existing link to Pyodide.

- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).