### PR TITLE
Add WasmBench dataset and paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [webm-wasm - Create webm videos in JavaScript via WebAssembly](https://github.com/GoogleChromeLabs/webm-wasm)
 - [wasm-pdf – Generate PDF files with JavaScript/WASM](https://github.com/jussiniinikoski/wasm-pdf)
 - [go-web-app – Quickly setup Go + WebAssembly frontend apps](https://github.com/talentlessguy/go-web-app)
+- [WasmBench - A large dataset of real-world WebAssembly binaries, collected from the Web, GitHub, NPM and more](https://github.com/sola-st/WasmBench)
 
 ## Languages
 
@@ -367,6 +368,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 ## Papers
 - [Bringing the Web up to Speed with WebAssembly](https://github.com/WebAssembly/spec/blob/master/papers/pldi2017.pdf)
 - [The Web Assembles](http://blog.scottlogic.com/ceberhardt/assets/white-papers/the-web-assembles.pdf)
+- [An Empirical Study of Real-World WebAssembly Binaries: Security, Languages, Use Cases](https://dlehmann.eu/publications/WasmBench-www2021.pdf)
 
 ## Demos
 - [Aphrós - finite volume solver for incompressible multiphase flows](https://cselab.github.io/aphros/wasm/hydro.html)


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).

https://github.com/sola-st/WasmBench
WasmBench is a large dataset of more than 8400 real-world WebAssembly binaries, collected from live websites, GitHub, NPM packages, browser extensions, and more sources. The dataset is useful, e.g., for testing WebAssembly-related tools, as training data for machine learning, and because of the insights how WebAssembly is used in practice (e.g., from which source languages Wasm binaries are commonly compiled, what imports they use, how large they are, etc.) The dataset is described in more detail in [a paper published at _The Web Conference 2021_](https://dlehmann.eu/publications/WasmBench-www2021.pdf), which goes into more detail of the methodology for collecting the binaries and our statistical evaluation.