### PR TITLE
Fix Pyodide and PyScript links

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,8 +221,8 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [wasicaml - Translate OCaml Bytecode to WASM](https://github.com/remixlabs/wasicaml/)
 
 ### Python
-- [Pyodide - The Python scientific stack running in the browser](https://github.com/pyscript/)
-- [PyScript - Run Python Code and the scientific stack in the browser](https://github.com/iodide-project/pyodide)
+- [Pyodide - The Python scientific stack running in the browser](https://github.com/iodide-project/pyodide)
+- [PyScript - Run Python Code and the scientific stack in the browser](https://github.com/pyscript/)
 - [python-wasm - WebAssembly CPython for Node.js and the browser built using Zig (no emscripten)](https://python-wasm.cocalc.com/)
 - [Rocket game - Rocket, written in Rust, compiled to WASM, running in Python](https://github.com/almarklein/rocket_rust_py/) (using [PPCI](http://ppci.readthedocs.io))
 


### PR DESCRIPTION
Pyodide linked to PyScript github and PyScript linked to Pyodide github. 

Swapped Pyodide and PyScript links url with each other.

- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).