### PR TITLE
Add wasm-bpf: Wasm library and toolchain for eBPF

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [go-web-app – Quickly setup Go + WebAssembly frontend apps](https://github.com/talentlessguy/go-web-app)
 - [gotemplate.io – Quicky test and visualize your Go templates live](https://gotemplate.io/)
 - [WasmBench - A large dataset of real-world WebAssembly binaries, collected from the Web, GitHub, NPM and more](https://github.com/sola-st/WasmBench)
+- [wasm-bpf - A WebAssembly eBPF library, toolchain and runtime to help you build eBPF programs to Wasm and run in kernel.](https://github.com/eunomia-bpf/wasm-bpf)
 
 ## Languages
 


### PR DESCRIPTION
See https://github.com/eunomia-bpf/wasm-bpf.

`Wasm-bpf` is a WebAssembly eBPF library, toolchain and runtime powered by CO-RE (Compile Once – Run Everywhere) libbpf and WAMR. It can help you build almost every eBPF programs or use cases to Wasm.

- [X] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).