### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [speedy.js - Accelerate JavaScript Applications by Compiling to WebAssembly (unmaintained)](https://github.com/MichaReiser/speedy.js)
 
 ### Kotlin
-- [Kotlin/Native - Compile Kotlin code to native binaries](https://kotlinlang.org/docs/reference/native-overview.html)
+- [Kotlin/Wasm (Kotlin WebAssembly)](https://kotl.in/wasm)
 
 ### Lua
 - [wasm_lua - Lua VM running in a WASM environment](https://github.com/vvanders/wasm_lua)


### PR DESCRIPTION
Kotlin/Wasm (Kotlin WebAssembly) goes Experimental in Kotlin 1.8.20 release: https://kotl.in/wasm  Wasm support in Kotlin/Native (through LLVM) will be deprecated and removed.

- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).