### PR TITLE
Add Ada language

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,9 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 
 ## Languages
 
+### Ada
+- [adawebpack - GNAT-LLVM compiler for WebAssembly target, GNAT Run Time Library and Ada bindings for Web API](https://github.com/godunko/adawebpack)
+ 
 ### Esoteric
 - [funge.js - A Befunge JIT](https://github.com/serprex/befunge)
 


### PR DESCRIPTION
This adds a section for the Ada language, containing the link to the Ada compiler targeting WebAssembly.

- [X] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).
There's no related issue.