### PR TITLE
added tiny-wasm-runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [TinyGo - Go for embedded devices and WebAssembly.  Creates very small .wasm files.](https://github.com/aykevl/tinygo)
 - [Bytecoder - A Rich Domain Model for Java Bytecode and Framework to interpret and transpile it to other languages such as JavaScript, OpenCL or WebAssembly](https://github.com/mirkosertic/Bytecoder)
 - [AssemblyScript - Definitely not a TypeScript to WebAssembly compiler](https://github.com/AssemblyScript/assemblyscript)
+- [tiny-wasm-runtime - Lightweight, simpler, less feature rich alternative to emscripten for C/C++ to web assembly.](https://github.com/twiddlingbits/tiny-wasm-runtime)
 
 ## Non-Web Embeddings
 


### PR DESCRIPTION
added https://github.com/twiddlingbits/tiny-wasm-runtime.

I wasn't sure which category to add it to, so i added it to the same category that emscripten is in, because it is an alternative, lighterweight, simpler, less feature rich alternative to emscripten.

- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [x ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).