### PR TITLE
Fix: 'Learn Web-Assembly' eBook Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 
 ## Books
 - [WebAssembly Reference Manual](https://github.com/sunfishcode/wasm-reference-manual)
-- [Learn WebAssembly - Build web applications with native performance using Wasm and C/C++](https://www.packtpub.com/web-development/learn-webassembly)
+- [Learn WebAssembly - Build web applications with native performance using Wasm and C/C++](https://www.packtpub.com/en-us/product/learn-webassembly-9781788995467)
 - [Programming WebAssembly with Rust - Unified Development for Web, Mobile, and Embedded Applications](https://pragprog.com/book/khrust/programming-webassembly-with-rust)
 - [Rust and WebAssembly](https://rustwasm.github.io/docs/book/)
 - [WebAssembly in Action - Introduces the WebAssembly stack and walks you through the process of writing and running browser-based applications](https://www.manning.com/books/webassembly-in-action)


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).

Link is 404 for this book. The change I've proposed fixes this.