### PR TITLE
Add WALI to non-web embedding projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [windtrap - A WASM VM written in Elixir](https://github.com/gballet/windtrap)
 - [Extism - the universal plug-in system to make your software programmable](https://github.com/extism/extism)
 - [Owi - a Wasm interpreter written in OCaml](https://github.com/OCamlPro/owi)
+- [WALI - A Low-Level Linux Virtualization Interface Leveraging Webassembly](https://github.com/arjunr2/WALI)
 
 ## Projects
 


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).

WALI is the WebAssembly Linux Interface which allows most Linux applications to port seamlessly over Wasm unmodified.