### PR TITLE
Add Linu.li to Demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [Squoosh.app - Compress and compare images with different codecs, right in your browser](https://squoosh.app)
 - [SketchUp - 3D modeling software](https://app.sketchup.com/app)
 - [WebViewer - a CAD, MS Office, and PDF SDK](https://www.pdftron.com/webviewer/demo/)
+- [Linu.li - Privacy-first, client-side PDF and image manipulation tools using WebAssembly](https://linu.li)
 
 ## Resources in other languages
 


### PR DESCRIPTION
Hi! I'd like to add **Linu.li** to the Demos section.

It is a privacy-first toolbox that uses WebAssembly (via libraries like ffmpeg.wasm and various image codecs) to process files entirely in the browser without server uploads.

I have followed the formatting style `[Name - Desc](Link)` found in the Demos section.

Thanks!