### PR TITLE
Add PixHeic to WebAssembly resources list

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [wasmBoy Demo/Debugger - a Gameboy Emulation library written in Web Assembly using AssemblyScript](https://wasmboy.app/)
 - [DOOM 3 - Doom 3 WebAssembly port](http://wasm.continuation-labs.com/d3demo/)
 - [Squoosh.app - Compress and compare images with different codecs, right in your browser](https://squoosh.app)
+- [PixHeic - Fast, 100% client-side HEIC to JPG/PNG converter running in the browser via WebAssembly](https://pixheic.com) 
 - [SketchUp - 3D modeling software](https://app.sketchup.com/app)
 - [WebViewer - a CAD, MS Office, and PDF SDK](https://www.pdftron.com/webviewer/demo/)
 


### PR DESCRIPTION
Added PixHeic to the list of WebAssembly resources.

- [ ] I've read [CONTRIBUTING.md](https://github.com/mbasso/awesome-wasm/blob/master/CONTRIBUTING.md).
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).